### PR TITLE
Implement dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ npm start
 
 Esto abrirá un servidor en `http://localhost:3000` desde donde podrás probar la aplicación.
 
+## Modo claro y oscuro
+
+Desde la barra de navegación puedes cambiar entre el tema claro y oscuro. La elección se guarda en `localStorage` para mantener la preferencia en futuras visitas.
+

--- a/css/style.css
+++ b/css/style.css
@@ -43,10 +43,30 @@
             text-decoration: none;
             margin: 0 10px;
         }
-        .logo {
-            margin-left: 10%;
-            font-weight: 500;
-        }
+.logo {
+    margin-left: 10%;
+    font-weight: 500;
+}
+
+.toggle-mode {
+    margin-left: auto;
+    margin-right: 10%;
+    display: flex;
+    align-items: center;
+}
+
+#theme-toggle {
+    margin-left: 20px;
+    background: none;
+    border: none;
+    color: white;
+    font-size: 2.4rem;
+    cursor: pointer;
+}
+
+#theme-toggle i {
+    pointer-events: none;
+}
         /* Estilos para la sección del clima */
         #clima-info {
             display: flex;
@@ -159,7 +179,33 @@
                 position: static;      
             }
 
-            #api-link, #api-image {
-                display: none;
-            }
+        #api-link, #api-image {
+            display: none;
         }
+        }
+
+/* Tema oscuro */
+body.dark-mode {
+    background-color: #2D2C2C;
+    color: #f8f9fa;
+}
+
+body.dark-mode .weather-card {
+    background-color: #262626;
+    border-color: #444;
+    color: #f8f9fa;
+}
+
+body.dark-mode .search-input {
+    background-color: #444;
+    color: #fff;
+    border-color: #666;
+}
+
+body.dark-mode a {
+    color: #ffc107;
+}
+
+body.dark-mode #theme-toggle {
+    color: #fff;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -1,48 +1,54 @@
 @import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
 
+:root {
+    --primary-color: #3d94f0;
+    --secondary-color: #6c757d;
+    --success-color: #28a745;
+    --info-color: #17a2b8;
+    --warning-color: #ffc107;
+    --danger-color: #dc3545;
+    --light-color: #f8f9fa;
+    --dark-color: #343a40;
+    --text-color: #333;
 
-        :root {
-            --primary-color: #3d94f0;
-            --secondary-color: #6c757d;
-            --success-color: #28a745;
-            --info-color: #17a2b8;
-            --warning-color: #ffc107;
-            --danger-color: #dc3545;
-            --light-color: #f8f9fa;
-            --dark-color: #343a40;
-            --text-color: #333;
-        }
+    --white-color: #ffffff;
+    --gray-light-color: #cccccc;
+    --gray-dark-color: #444444;
+    --gray-darker-color: #262626;
+    --gray-background-input: #444444;
+}
 
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-            font-family: 'Poppins', sans-serif;
-        }
-        html {
-            font-size: 62.5%;
-            overflow: auto;
-        }
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: 'Poppins', sans-serif;
+}
 
-        body {
-            font-size: 1.6rem;
-            background-color: var(--light-color);
-            color: var(--text-color);
-        }
-        
-        .navbar {
-            background-color: var(--primary-color);
-            font-size: 24px;
-            padding: 10px 0;
-            font-size: 36px;
-            display:flex ; /* Ajustar el tamaño del texto */ 
-        }
+html {
+    font-size: 62.5%;
+    overflow: auto;
+}
 
-        .navbar a {
-            color: white;
-            text-decoration: none;
-            margin: 0 10px;
-        }
+body {
+    font-size: 1.6rem;
+    background-color: var(--light-color);
+    color: var(--text-color);
+}
+
+.navbar {
+    background-color: var(--primary-color);
+    font-size: 36px;
+    padding: 10px 0;
+    display: flex;
+}
+
+.navbar a {
+    color: var(--white-color);
+    text-decoration: none;
+    margin: 0 10px;
+}
+
 .logo {
     margin-left: 10%;
     font-weight: 500;
@@ -59,7 +65,7 @@
     margin-left: 20px;
     background: none;
     border: none;
-    color: white;
+    color: var(--white-color);
     font-size: 2.4rem;
     cursor: pointer;
 }
@@ -67,145 +73,163 @@
 #theme-toggle i {
     pointer-events: none;
 }
-        /* Estilos para la sección del clima */
-        #clima-info {
-            display: flex;
-            justify-content: space-around;
-            margin-top: 30px;
-        }
-        .weather-card {
-            text-align: center;
-            padding: 20px;
-            border-radius: 10px;
-            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-            background-color: #fff;
-            width: 200px;
-            border: 1px solid #ccc;
-        }
-        .weather-card img {
-            max-width: 100px;
-            margin-bottom: 10px;
-        }
-        .weather-card p {
-            margin-bottom: 5px;
-        }
-        /* Estilos para el buscador */
-        .search-box {
-            margin-top: 20px;
-            text-align: center;
-        }
-        .search-input {
-            padding: 8px;
-            border-radius: 5px;
-            border: 1px solid #ccc;
-        }
-        .search-btn {
-            padding: 8px 12px;
-            border-radius: 5px;
-            border: none;
-            background-color: var(--primary-color);
-            color: var(--light-color);
-            cursor: pointer;
-        }
-        .search-btn:hover {
-            background-color: var(--dark-color);
-        }
-        #footer {
-            align-items: flex-end;      
-            width: 100%;
-            background-color: var(--primary-color);
-            color: white;
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            padding: 10px 5%;
-        }
-        
-        
 
-        a {
-            color: var(--warning-color);
-        }
+/* Estilos para la sección del clima */
+#clima-info {
+    display: flex;
+    justify-content: space-around;
+    margin-top: 30px;
+}
 
-        a:hover {
-            color: var(--danger-color);
-        }
+.weather-card {
+    text-align: center;
+    padding: 20px;
+    border-radius: 10px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    background-color: var(--white-color);
+    width: 200px;
+    border: 1px solid var(--gray-light-color);
+}
 
+.weather-card img {
+    max-width: 100px;
+    margin-bottom: 10px;
+}
 
-        .sticky {
-            position: sticky;
-            bottom: 0;
-        }
-        
-        .absolute {
-            position: absolute;
-            bottom: 0;
-        }
+.weather-card p {
+    margin-bottom: 5px;
+}
 
-        .expand-btn {
-            background-color: var(--primary-color);
-            color: white;
-            padding: 5px 10px;
-            border-radius: 5px;
-            cursor: pointer;
-        }
+/* Estilos para el buscador */
+.search-box {
+    margin-top: 20px;
+    text-align: center;
+}
 
-        .expand-btn:hover {
-            background-color: var(--dark-color);
-        }
+.search-input {
+    padding: 8px;
+    border-radius: 5px;
+    border: 1px solid var(--gray-light-color);
+}
 
-        .expand-btn:active {
-            background-color: var(--light-color);
-            color: var(--dark-color);
-        }
+.search-btn {
+    padding: 8px 12px;
+    border-radius: 5px;
+    border: none;
+    background-color: var(--primary-color);
+    color: var(--light-color);
+    cursor: pointer;
+}
 
+.search-btn:hover {
+    background-color: var(--dark-color);
+}
 
-        @media (max-width: 768px) {
-            .navbar {
-                font-size: 24px;
-            }
-            .logo {
-                margin-left: 5%;
-            }
-            #clima-info {
-                flex-direction: column;
-                display: grid;
-            }
-            .weather-card {
-                margin-bottom: 20px;
-            }
+#footer {
+    align-items: flex-end;
+    width: 100%;
+    background-color: var(--primary-color);
+    color: var(--white-color);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 5%;
+}
 
-            .absolute {
-                position: static;      
-            }
+a {
+    color: var(--warning-color);
+}
 
-        #api-link, #api-image {
-            display: none;
-        }
-        }
+a:hover {
+    color: var(--danger-color);
+}
+
+.sticky {
+    position: sticky;
+    bottom: 0;
+}
+
+.absolute {
+    position: absolute;
+    bottom: 0;
+}
+
+.expand-btn {
+    background-color: var(--primary-color);
+    color: var(--white-color);
+    padding: 5px 10px;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+.expand-btn:hover {
+    background-color: var(--dark-color);
+}
+
+.expand-btn:active {
+    background-color: var(--light-color);
+    color: var(--dark-color);
+}
+
+@media (max-width: 768px) {
+    .navbar {
+        font-size: 24px;
+    }
+
+    .logo {
+        margin-left: 5%;
+    }
+
+    #clima-info {
+        flex-direction: column;
+        display: grid;
+    }
+
+    .weather-card {
+        margin-bottom: 20px;
+    }
+
+    .absolute {
+        position: static;
+    }
+
+    #api-link, #api-image {
+        display: none;
+    }
+}
 
 /* Tema oscuro */
 body.dark-mode {
     background-color: #2D2C2C;
-    color: #f8f9fa;
+    color: var(--light-color);
 }
 
 body.dark-mode .weather-card {
-    background-color: #262626;
-    border-color: #444;
-    color: #f8f9fa;
+    background-color: var(--gray-darker-color);
+    border-color: var(--gray-dark-color);
+    color: var(--light-color);
 }
 
 body.dark-mode .search-input {
-    background-color: #444;
-    color: #fff;
-    border-color: #666;
+    background-color: var(--gray-background-input);
+    color: var(--white-color);
+    border-color: var(--gray-dark-color);
 }
 
 body.dark-mode a {
-    color: #ffc107;
+    color: var(--warning-color);
 }
 
 body.dark-mode #theme-toggle {
-    color: #fff;
+    color: var(--white-color);
+}
+
+#theme-toggle:hover {
+    color: var(--warning-color);
+    transform: scale(1.1);
+    transition: color 0.3s, transform 0.3s;
+}
+
+body.dark-mode #theme-toggle:hover {
+    color: var(--warning-color);
 }

--- a/index.html
+++ b/index.html
@@ -21,6 +21,9 @@
         </div>
         <div class="toggle-mode">
             <div class="logo">ClimAPP</div>
+            <button id="theme-toggle" aria-label="Cambiar tema">
+                <i id="theme-icon" class='bx bx-moon'></i>
+            </button>
         </div>
     </nav>
 

--- a/js/main.js
+++ b/js/main.js
@@ -3,7 +3,33 @@ import { searchWeather, getWeatherByUserLocation, toggleHourlyForecast, setWeath
 window.searchWeather = searchWeather;
 window.toggleHourlyForecast = toggleHourlyForecast;
 
+function applySavedTheme() {
+  const saved = localStorage.getItem('theme');
+  if (saved === 'dark') {
+    document.body.classList.add('dark-mode');
+    const icon = document.getElementById('theme-icon');
+    if (icon) {
+      icon.classList.replace('bx-moon', 'bx-sun');
+    }
+  }
+}
+
+function toggleTheme() {
+  const isDark = document.body.classList.toggle('dark-mode');
+  const icon = document.getElementById('theme-icon');
+  if (icon) {
+    icon.classList.toggle('bx-moon', !isDark);
+    icon.classList.toggle('bx-sun', isDark);
+  }
+  localStorage.setItem('theme', isDark ? 'dark' : 'light');
+}
+
 window.onload = () => {
   getWeatherByUserLocation();
   setWeatherIcon();
+  applySavedTheme();
+  const btn = document.getElementById('theme-toggle');
+  if (btn) {
+    btn.addEventListener('click', toggleTheme);
+  }
 };

--- a/js/main.js
+++ b/js/main.js
@@ -1,28 +1,8 @@
 import { searchWeather, getWeatherByUserLocation, toggleHourlyForecast, setWeatherIcon } from './ui.js';
+import { applySavedTheme, toggleTheme } from './toggleTheme.js';
 
 window.searchWeather = searchWeather;
 window.toggleHourlyForecast = toggleHourlyForecast;
-
-function applySavedTheme() {
-  const saved = localStorage.getItem('theme');
-  if (saved === 'dark') {
-    document.body.classList.add('dark-mode');
-    const icon = document.getElementById('theme-icon');
-    if (icon) {
-      icon.classList.replace('bx-moon', 'bx-sun');
-    }
-  }
-}
-
-function toggleTheme() {
-  const isDark = document.body.classList.toggle('dark-mode');
-  const icon = document.getElementById('theme-icon');
-  if (icon) {
-    icon.classList.toggle('bx-moon', !isDark);
-    icon.classList.toggle('bx-sun', isDark);
-  }
-  localStorage.setItem('theme', isDark ? 'dark' : 'light');
-}
 
 window.onload = () => {
   getWeatherByUserLocation();

--- a/js/toggleTheme.js
+++ b/js/toggleTheme.js
@@ -1,0 +1,20 @@
+export function applySavedTheme() {
+  const saved = localStorage.getItem('theme');
+  if (saved === 'dark') {
+    document.body.classList.add('dark-mode');
+    const icon = document.getElementById('theme-icon');
+    if (icon) {
+      icon.classList.replace('bx-moon', 'bx-sun');
+    }
+  }
+}
+
+export function toggleTheme() {
+  const isDark = document.body.classList.toggle('dark-mode');
+  const icon = document.getElementById('theme-icon');
+  if (icon) {
+    icon.classList.toggle('bx-moon', !isDark);
+    icon.classList.toggle('bx-sun', isDark);
+  }
+  localStorage.setItem('theme', isDark ? 'dark' : 'light');
+}


### PR DESCRIPTION
## Summary
- add theme toggle button to navigation
- style theme toggle and add dark theme CSS
- implement theme persistence with localStorage
- mention dark mode in documentation

## Testing
- `npm start` *(server launched and logged URL)*

------
https://chatgpt.com/codex/tasks/task_e_6884330209348333877e2906e96cb606