### PR TITLE
Implement seven-day forecast carousel

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ Esto abrirá un servidor en `http://localhost:3000` desde donde podrás probar l
 
 Desde la barra de navegación puedes cambiar entre el tema claro y oscuro. La elección se guarda en `localStorage` para mantener la preferencia en futuras visitas.
 
+## Pronóstico extendido
+
+La aplicación muestra ahora el clima de los próximos **7 días** utilizando un carrusel. Puedes desplazarte entre las tarjetas para revisar el pronóstico de cada jornada.
+

--- a/css/style.css
+++ b/css/style.css
@@ -233,3 +233,14 @@ body.dark-mode #theme-toggle {
 body.dark-mode #theme-toggle:hover {
     color: var(--warning-color);
 }
+
+/* Estilos para el carrusel de pronóstico */
+.swiper {
+    width: 100%;
+    padding: 20px 0;
+}
+
+.swiper-slide {
+    display: flex;
+    justify-content: center;
+}

--- a/index.html
+++ b/index.html
@@ -38,33 +38,9 @@
             </form>
         </div>
 
-        <div id="clima-info">
-            <div class="weather-card" id="today">
-                <h3>Hoy</h3>
-                <img src="" alt="Hoy">
-                <p id="today-description"></p>
-                <p id="today-temperature"></p>
-                <button class="expand-btn" onclick="toggleHourlyForecast('today')">Mostrar por horas</button>
-                <div class="hourly-forecast" id="today-hourly-forecast"></div>
-            </div>
-            
-            <div class="weather-card" id="tomorrow">
-                <h3>Mañana</h3>
-                <img src="" alt="Mañana">
-                <p id="tomorrow-description"></p>
-                <p id="tomorrow-temperature"></p>
-                <button class="expand-btn" onclick="toggleHourlyForecast('tomorrow')">Mostrar por horas</button>
-                <div class="hourly-forecast" id="tomorrow-hourly-forecast"></div>
-            </div>
-            
-            <div class="weather-card" id="day-after-tomorrow">
-                <h3>Pasado mañana</h3>
-                <img src="" alt="Pasado mañana">
-                <p id="day-after-tomorrow-description"></p>
-                <p id="day-after-tomorrow-temperature"></p>
-                <button class="expand-btn" onclick="toggleHourlyForecast('day-after-tomorrow')">Mostrar por horas</button>
-                <div class="hourly-forecast" id="day-after-tomorrow-hourly-forecast"></div>
-            </div>
+        <div class="swiper mySwiper">
+            <div class="swiper-wrapper" id="clima-info"></div>
+            <div class="swiper-pagination"></div>
         </div>
 
         <footer id="footer" class="absolute">
@@ -79,6 +55,7 @@
                     <img src='//cdn.weatherapi.com/v4/images/weatherapi_logo.png' alt="Weather data by WeatherAPI.com" border="0">
                 </a>
         </footer>
+    <script src="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.js"></script>
     <script type="module" src="js/main.js"></script>
 </body>
 </html>

--- a/js/api.js
+++ b/js/api.js
@@ -1,7 +1,7 @@
 const apiKey = 'c4b6d68355b64c67840235826230212';
 const lang = 'es';
 
-export async function fetchWeatherForecast(city, days = 3) {
+export async function fetchWeatherForecast(city, days = 7) {
   const response = await fetch(`https://api.weatherapi.com/v1/forecast.json?key=${apiKey}&q=${city}&days=${days}&lang=${lang}`);
   return response.json();
 }

--- a/js/ui.js
+++ b/js/ui.js
@@ -34,21 +34,40 @@ export async function getWeatherByUserLocation() {
 }
 
 function updateWeatherCards(data) {
-  document.getElementById('today-description').innerText = data.forecast.forecastday[0].day.condition.text;
-  document.getElementById('tomorrow-description').innerText = data.forecast.forecastday[1].day.condition.text;
-  document.getElementById('day-after-tomorrow-description').innerText = data.forecast.forecastday[2].day.condition.text;
+  const container = document.getElementById('clima-info');
+  container.innerHTML = '';
+  data.forecast.forecastday.forEach((day, index) => {
+    const card = document.createElement('div');
+    card.className = 'weather-card swiper-slide';
+    card.id = `day-${index}`;
+    const title = index === 0 ? 'Hoy' : index === 1 ? 'Mañana' : day.date;
+    card.innerHTML = `
+      <h3>${title}</h3>
+      <img src="${day.day.condition.icon}" alt="${day.day.condition.text}">
+      <p id="day-${index}-description">${day.day.condition.text}</p>
+      <p id="day-${index}-temperature">${day.day.avgtemp_c}°C</p>
+      <button class="expand-btn" onclick="toggleHourlyForecast(${index})">Mostrar por horas</button>
+      <div class="hourly-forecast" id="hourly-${index}"></div>
+    `;
+    container.appendChild(card);
+  });
 
-  document.getElementById('today').getElementsByTagName('img')[0].src = data.forecast.forecastday[0].day.condition.icon;
-  document.getElementById('tomorrow').getElementsByTagName('img')[0].src = data.forecast.forecastday[1].day.condition.icon;
-  document.getElementById('day-after-tomorrow').getElementsByTagName('img')[0].src = data.forecast.forecastday[2].day.condition.icon;
-
-  document.getElementById('today-temperature').innerText = data.forecast.forecastday[0].day.avgtemp_c + '°C';
-  document.getElementById('tomorrow-temperature').innerText = data.forecast.forecastday[1].day.avgtemp_c + '°C';
-  document.getElementById('day-after-tomorrow-temperature').innerText = data.forecast.forecastday[2].day.avgtemp_c + '°C';
+  if (window.mySwiper) {
+    window.mySwiper.update();
+  } else {
+    window.mySwiper = new Swiper('.mySwiper', {
+      slidesPerView: 1,
+      spaceBetween: 20,
+      pagination: {
+        el: '.swiper-pagination',
+        clickable: true,
+      },
+    });
+  }
 }
 
-export async function toggleHourlyForecast(cardId) {
-  const card = document.getElementById(cardId);
+export async function toggleHourlyForecast(index) {
+  const card = document.getElementById(`day-${index}`);
   const hourlyForecastDiv = card.querySelector('.hourly-forecast');
 
   if (hourlyForecastDiv.style.display === 'block') {
@@ -61,7 +80,6 @@ export async function toggleHourlyForecast(cardId) {
       return;
     }
 
-    const index = cardId === 'today' ? 0 : cardId === 'tomorrow' ? 1 : 2;
     const hourlyForecast = await getHourlyForecast(city, index);
 
     if (hourlyForecast) {


### PR DESCRIPTION
## Summary
- fetch 7 days of weather data
- render forecast cards dynamically
- support hourly forecast for any day
- display cards inside a swiper carousel
- document extended forecast

## Testing
- `npm start` *(fails: server terminates after manual stop)*

------
https://chatgpt.com/codex/tasks/task_e_68846bb8acb48333882ff6675b0fa6af