### PR TITLE
Add Progressive Web App support

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,9 @@
 
     <!-- custom css -->
     <link rel="stylesheet" href="css/style.css">
+
+    <link rel="manifest" href="manifest.json">
+    <meta name="theme-color" content="#3d94f0">
 </head>
 <body>
 
@@ -82,5 +85,14 @@
                 </a>
         </footer>
     <script type="module" src="js/main.js"></script>
+    <script>
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', function() {
+                navigator.serviceWorker.register('/sw.js').catch(function(err) {
+                    console.log('Service Worker registration failed:', err);
+                });
+            });
+        }
+    </script>
 </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "ClimAPP",
+  "short_name": "ClimAPP",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#3d94f0",
+  "icons": [
+    {
+      "src": "images/sun.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "images/sun.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,37 @@
+const CACHE_NAME = 'climapp-cache-v1';
+const ASSETS_TO_CACHE = [
+  '/',
+  '/index.html',
+  '/css/style.css',
+  '/js/main.js',
+  '/js/api.js',
+  '/js/ui.js',
+  '/js/toggleTheme.js',
+  '/images/sun.png',
+  '/manifest.json'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then(cache => cache.addAll(ASSETS_TO_CACHE))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => {
+      return Promise.all(
+        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+      );
+    })
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(cached => {
+      return cached || fetch(event.request);
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add `manifest.json` with icons and theme info
- register service worker in `index.html`
- create `sw.js` for offline caching

## Testing
- `npm install`
- `npm start` (server runs)

------
https://chatgpt.com/codex/tasks/task_e_6885c70ea8ec8333981202959d3d2fd6