### PR TITLE
Add multi-language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,8 @@ Esto abrirá un servidor en `http://localhost:3000` desde donde podrás probar l
 
 Desde la barra de navegación puedes cambiar entre el tema claro y oscuro. La elección se guarda en `localStorage` para mantener la preferencia en futuras visitas.
 
+## Soporte multilenguaje
+
+También desde la barra de navegación puedes seleccionar el idioma (español o inglés).
+La selección modifica el parámetro `lang` utilizado al consultar la API y traduce automáticamente los textos de la interfaz.
+

--- a/css/style.css
+++ b/css/style.css
@@ -65,6 +65,10 @@ body {
     margin-left: 20px;
     padding: 5px;
     font-size: 1.6rem;
+    color: var(--white-color);
+    background-color: transparent;
+    border: 1px solid var(--white-color);
+    border-radius: 4px;
 }
 
 #theme-toggle {

--- a/css/style.css
+++ b/css/style.css
@@ -61,16 +61,6 @@ body {
     align-items: center;
 }
 
-#lang-select {
-    margin-left: 20px;
-    padding: 5px;
-    font-size: 1.6rem;
-    color: var(--white-color);
-    background-color: transparent;
-    border: 1px solid var(--white-color);
-    border-radius: 4px;
-}
-
 #theme-toggle {
     margin-left: 20px;
     background: none;
@@ -234,12 +224,6 @@ body.dark-mode a {
 
 body.dark-mode #theme-toggle {
     color: var(--white-color);
-}
-
-body.dark-mode #lang-select {
-    background-color: var(--gray-dark-color);
-    color: var(--white-color);
-    border: none;
 }
 
 #theme-toggle:hover {

--- a/css/style.css
+++ b/css/style.css
@@ -61,6 +61,12 @@ body {
     align-items: center;
 }
 
+#lang-select {
+    margin-left: 20px;
+    padding: 5px;
+    font-size: 1.6rem;
+}
+
 #theme-toggle {
     margin-left: 20px;
     background: none;
@@ -224,6 +230,12 @@ body.dark-mode a {
 
 body.dark-mode #theme-toggle {
     color: var(--white-color);
+}
+
+body.dark-mode #lang-select {
+    background-color: var(--gray-dark-color);
+    color: var(--white-color);
+    border: none;
 }
 
 #theme-toggle:hover {

--- a/css/style.css
+++ b/css/style.css
@@ -70,6 +70,10 @@ body {
     border: 1px solid var(--white-color);
     border-radius: 4px;
 }
+#lang-select:hover {
+   transform: scale(1.1);
+   transition: transform 0.3s;
+}
 
 #lang-select option {
     color: var(--text-color);

--- a/index.html
+++ b/index.html
@@ -24,6 +24,10 @@
         </div>
         <div class="toggle-mode">
             <div class="logo">ClimAPP</div>
+            <select id="lang-select" aria-label="Idioma">
+                <option value="es">ES</option>
+                <option value="en">EN</option>
+            </select>
             <button id="theme-toggle" aria-label="Cambiar tema">
                 <i id="theme-icon" class='bx bx-moon'></i>
             </button>

--- a/js/api.js
+++ b/js/api.js
@@ -1,12 +1,15 @@
+import { getLang } from './lang.js';
+
 const apiKey = 'c4b6d68355b64c67840235826230212';
-const lang = 'es';
 
 export async function fetchWeatherForecast(city, days = 3) {
+  const lang = getLang();
   const response = await fetch(`https://api.weatherapi.com/v1/forecast.json?key=${apiKey}&q=${city}&days=${days}&lang=${lang}`);
   return response.json();
 }
 
 export async function fetchCurrentWeatherByCoords(lat, lon) {
+  const lang = getLang();
   const response = await fetch(`https://api.weatherapi.com/v1/current.json?key=${apiKey}&q=${lat},${lon}&lang=${lang}`);
   return response.json();
 }

--- a/js/lang.js
+++ b/js/lang.js
@@ -1,0 +1,61 @@
+export let currentLang = localStorage.getItem('lang') || 'es';
+
+export function setLang(lang) {
+  currentLang = lang;
+  localStorage.setItem('lang', lang);
+}
+
+export function getLang() {
+  return currentLang;
+}
+
+const translations = {
+  es: {
+    searchPlaceholder: 'Buscar ciudad',
+    showHourly: 'Mostrar por horas',
+    today: 'Hoy',
+    tomorrow: 'Mañana',
+    dayAfterTomorrow: 'Pasado mañana',
+    hourlyWarning: 'Introduce una ciudad para ver el pronóstico por horas.',
+    errorGeneric: 'Hubo un error al obtener datos del clima. Por favor, inténtalo de nuevo más tarde.',
+    errorFetching: 'No se pudo obtener la información del clima. Inténtalo de nuevo.',
+    errorHourlyGeneric: 'Hubo un error al obtener datos del clima por horas. Por favor, inténtalo de nuevo más tarde.',
+    errorHourlyFetching: 'No se pudo obtener la información del clima por horas. Inténtalo de nuevo.'
+  },
+  en: {
+    searchPlaceholder: 'Search city',
+    showHourly: 'Show hourly',
+    today: 'Today',
+    tomorrow: 'Tomorrow',
+    dayAfterTomorrow: 'Day After Tomorrow',
+    hourlyWarning: 'Enter a city to see the hourly forecast.',
+    errorGeneric: 'There was an error fetching weather data. Please try again later.',
+    errorFetching: 'Could not retrieve weather information. Please try again.',
+    errorHourlyGeneric: 'There was an error fetching hourly weather data. Please try again later.',
+    errorHourlyFetching: 'Could not retrieve hourly weather information. Please try again.'
+  }
+};
+
+export function t(key) {
+  const langSet = translations[currentLang] || translations.es;
+  return langSet[key] || key;
+}
+
+export function applyTranslations() {
+  const cityInput = document.getElementById('city-input');
+  if (cityInput) cityInput.placeholder = t('searchPlaceholder');
+
+  const select = document.getElementById('lang-select');
+  if (select) select.value = currentLang;
+
+  const today = document.querySelector('#today h3');
+  if (today) today.innerText = t('today');
+  const tomorrow = document.querySelector('#tomorrow h3');
+  if (tomorrow) tomorrow.innerText = t('tomorrow');
+  const dayAfter = document.querySelector('#day-after-tomorrow h3');
+  if (dayAfter) dayAfter.innerText = t('dayAfterTomorrow');
+
+  document.querySelectorAll('.expand-btn').forEach(btn => {
+    btn.innerText = t('showHourly');
+  });
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,6 @@
 import { searchWeather, getWeatherByUserLocation, toggleHourlyForecast, setWeatherIcon, loadCityHistory } from './ui.js';
 import { applySavedTheme, toggleTheme } from './toggleTheme.js';
+import { applyTranslations, setLang } from './lang.js';
 
 window.searchWeather = searchWeather;
 window.toggleHourlyForecast = toggleHourlyForecast;
@@ -9,8 +10,17 @@ window.onload = () => {
   setWeatherIcon();
   applySavedTheme();
   loadCityHistory();
+  applyTranslations();
   const btn = document.getElementById('theme-toggle');
   if (btn) {
     btn.addEventListener('click', toggleTheme);
+  }
+  const langSelect = document.getElementById('lang-select');
+  if (langSelect) {
+    langSelect.addEventListener('change', (e) => {
+      setLang(e.target.value);
+      applyTranslations();
+      searchWeather();
+    });
   }
 };

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,4 +1,5 @@
 import { fetchWeatherForecast, fetchCurrentWeatherByCoords } from './api.js';
+import { t } from './lang.js';
 
 const footer = document.getElementById('footer');
 
@@ -7,14 +8,14 @@ export async function searchWeather() {
   try {
     const data = await fetchWeatherForecast(cityInput);
     if (data.error) {
-      alert('No se pudo obtener la información del clima. Inténtalo de nuevo.');
+      alert(t('errorFetching'));
       return;
     }
     updateWeatherCards(data);
     saveCityToHistory(cityInput);
   } catch (error) {
     console.error('Hubo un error al obtener datos del clima:', error);
-    alert('Hubo un error al obtener datos del clima. Por favor, inténtalo de nuevo más tarde.');
+    alert(t('errorGeneric'));
   }
 }
 
@@ -58,7 +59,7 @@ export async function toggleHourlyForecast(cardId) {
   } else {
     const city = document.getElementById('city-input').value.trim();
     if (!city) {
-      alert('Introduce una ciudad para ver el pronóstico por horas.');
+      alert(t('hourlyWarning'));
       return;
     }
 
@@ -89,13 +90,13 @@ async function getHourlyForecast(city, index) {
   try {
     const data = await fetchWeatherForecast(city, index + 1);
     if (data.error) {
-      alert('No se pudo obtener la información del clima por horas. Inténtalo de nuevo.');
+      alert(t('errorHourlyFetching'));
       return null;
     }
     return data.forecast.forecastday[index].hour;
   } catch (error) {
     console.error('Hubo un error al obtener datos del clima por horas:', error);
-    alert('Hubo un error al obtener datos del clima por horas. Por favor, inténtalo de nuevo más tarde.');
+    alert(t('errorHourlyGeneric'));
     return null;
   }
 }

--- a/sw.js
+++ b/sw.js
@@ -6,6 +6,7 @@ const ASSETS_TO_CACHE = [
   '/js/main.js',
   '/js/api.js',
   '/js/ui.js',
+  '/js/lang.js',
   '/js/toggleTheme.js',
   '/images/sun.png',
   '/manifest.json'


### PR DESCRIPTION
## Summary
- enable dynamic language setting in API requests
- add `lang.js` to manage translations and current language
- translate UI labels and error messages
- add language selector dropdown in navbar
- update styles for the new dropdown
- document multi-language feature in README

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6885cbcc9370833390c3b0ae3827e560