### PR TITLE
Add toast notifications for error handling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -315,3 +315,39 @@ body.dark-mode .recent-city .close-btn {
     color: var(--white-color);
     background-color: var(--danger-color);
 }
+
+/* Toast notifications */
+#toast-container {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    z-index: 10000;
+}
+
+.toast {
+    min-width: 200px;
+    margin-top: 10px;
+    padding: 10px 15px;
+    border-radius: 4px;
+    color: var(--white-color);
+    background-color: var(--info-color);
+    opacity: 0;
+    transform: translateX(100%);
+    transition: opacity 0.3s, transform 0.3s;
+}
+
+.toast.show {
+    opacity: 1;
+    transform: translateX(0);
+}
+
+.toast.success { background-color: var(--success-color); }
+.toast.error { background-color: var(--danger-color); }
+.toast.warning { background-color: var(--warning-color); }
+
+body.dark-mode .toast {
+    color: var(--white-color);
+}

--- a/index.html
+++ b/index.html
@@ -88,6 +88,7 @@
                     <img src='//cdn.weatherapi.com/v4/images/weatherapi_logo.png' alt="Weather data by WeatherAPI.com" border="0">
                 </a>
         </footer>
+    <div id="toast-container"></div>
     <script type="module" src="js/main.js"></script>
     <script>
         if ('serviceWorker' in navigator) {

--- a/js/toast.js
+++ b/js/toast.js
@@ -1,0 +1,26 @@
+let container;
+
+export function showToast(message, type = 'info') {
+  if (!container) {
+    container = document.getElementById('toast-container');
+    if (!container) {
+      container = document.createElement('div');
+      container.id = 'toast-container';
+      document.body.appendChild(container);
+    }
+  }
+  const toast = document.createElement('div');
+  toast.className = `toast ${type}`;
+  toast.textContent = message;
+  container.appendChild(toast);
+
+  // trigger animation
+  requestAnimationFrame(() => {
+    toast.classList.add('show');
+  });
+
+  setTimeout(() => {
+    toast.classList.remove('show');
+    toast.addEventListener('transitionend', () => toast.remove(), { once: true });
+  }, 4000);
+}

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,5 +1,6 @@
 import { fetchWeatherForecast, fetchCurrentWeatherByCoords } from './api.js';
 import { t } from './lang.js';
+import { showToast } from './toast.js';
 
 const footer = document.getElementById('footer');
 
@@ -8,14 +9,14 @@ export async function searchWeather() {
   try {
     const data = await fetchWeatherForecast(cityInput);
     if (data.error) {
-      alert(t('errorFetching'));
+      showToast(t('errorFetching'), 'error');
       return;
     }
     updateWeatherCards(data);
     saveCityToHistory(cityInput);
   } catch (error) {
     console.error('Hubo un error al obtener datos del clima:', error);
-    alert(t('errorGeneric'));
+    showToast(t('errorGeneric'), 'error');
   }
 }
 
@@ -59,7 +60,7 @@ export async function toggleHourlyForecast(cardId) {
   } else {
     const city = document.getElementById('city-input').value.trim();
     if (!city) {
-      alert(t('hourlyWarning'));
+      showToast(t('hourlyWarning'), 'warning');
       return;
     }
 
@@ -90,13 +91,13 @@ async function getHourlyForecast(city, index) {
   try {
     const data = await fetchWeatherForecast(city, index + 1);
     if (data.error) {
-      alert(t('errorHourlyFetching'));
+      showToast(t('errorHourlyFetching'), 'error');
       return null;
     }
     return data.forecast.forecastday[index].hour;
   } catch (error) {
     console.error('Hubo un error al obtener datos del clima por horas:', error);
-    alert(t('errorHourlyGeneric'));
+    showToast(t('errorHourlyGeneric'), 'error');
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- implement new toast module
- display toast messages instead of blocking alerts
- style notifications with new CSS rules
- include toast container in the HTML

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6886a1510ba48333869623103ab140b4