### PR TITLE
Enable npm test

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ npm start
 
 Esto abrirá un servidor en `http://localhost:3000` desde donde podrás probar la aplicación.
 
+## Pruebas
+
+Para ejecutar las pruebas automáticas utiliza:
+
+```bash
+npm test
+```
+
 ## Modo claro y oscuro
 
 Desde la barra de navegación puedes cambiar entre el tema claro y oscuro. La elección se guarda en `localStorage` para mantener la preferencia en futuras visitas.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Simple weather app",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test"
   },
   "author": "",
   "license": "ISC",

--- a/server.js
+++ b/server.js
@@ -2,38 +2,48 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 
-const port = process.env.PORT || 5500;
+function createApp() {
+  return http.createServer((req, res) => {
+    let filePath = '.' + req.url;
+    if (filePath === './') filePath = './index.html';
+    const ext = path.extname(filePath);
+    let contentType = 'text/html';
 
-http.createServer((req, res) => {
-  let filePath = '.' + req.url;
-  if (filePath === './') filePath = './index.html';
-  const ext = path.extname(filePath);
-  let contentType = 'text/html';
-
-  switch (ext) {
-    case '.js':
-      contentType = 'text/javascript';
-      break;
-    case '.css':
-      contentType = 'text/css';
-      break;
-    case '.png':
-      contentType = 'image/png';
-      break;
-    case '.json':
-      contentType = 'application/json';
-      break;
-  }
-
-  fs.readFile(filePath, (err, content) => {
-    if (err) {
-      res.writeHead(404);
-      res.end('File not found');
-    } else {
-      res.writeHead(200, { 'Content-Type': contentType });
-      res.end(content, 'utf-8');
+    switch (ext) {
+      case '.js':
+        contentType = 'text/javascript';
+        break;
+      case '.css':
+        contentType = 'text/css';
+        break;
+      case '.png':
+        contentType = 'image/png';
+        break;
+      case '.json':
+        contentType = 'application/json';
+        break;
     }
+
+    fs.readFile(filePath, (err, content) => {
+      if (err) {
+        res.writeHead(404);
+        res.end('File not found');
+      } else {
+        res.writeHead(200, { 'Content-Type': contentType });
+        res.end(content, 'utf-8');
+      }
+    });
   });
-}).listen(port, () => {
-  console.log(`Server running at http://localhost:${port}`);
-});
+}
+
+function startServer(port = process.env.PORT || 5500) {
+  return createApp().listen(port, () => {
+    console.log(`Server running at http://localhost:${port}`);
+  });
+}
+
+if (require.main === module) {
+  startServer();
+}
+
+module.exports = { createApp, startServer };

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,23 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { createApp } = require('../server');
+
+test('GET / serves index.html', async (t) => {
+  const server = createApp().listen(0);
+  t.after(() => server.close());
+  const port = server.address().port;
+  const res = await fetch(`http://localhost:${port}/`);
+  const text = await res.text();
+  assert.strictEqual(res.status, 200);
+  assert.match(text, /<html/i);
+});
+
+test('GET /nonexistent returns 404', async (t) => {
+  const server = createApp().listen(0);
+  t.after(() => server.close());
+  const port = server.address().port;
+  const res = await fetch(`http://localhost:${port}/no-file`);
+  const text = await res.text();
+  assert.strictEqual(res.status, 404);
+  assert.match(text, /File not found/);
+});


### PR DESCRIPTION
## Summary
- make server creation reusable and exportable
- use Node's builtin test runner
- add a simple server test
- document test command in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886b7079a2c8333be806a30a7aef91d