### PR TITLE
Add standalone hourly forecast cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -125,6 +125,15 @@ body {
     margin-top: 10px;
 }
 
+/* Container for hourly forecast cards */
+#hourly-cards {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 20px;
+    width: 100%;
+}
+
 /* Estilos para el buscador */
 .search-box {
     margin-top: 20px;

--- a/css/style.css
+++ b/css/style.css
@@ -119,6 +119,12 @@ body {
     margin-bottom: 5px;
 }
 
+/* Card that displays hourly forecast */
+.hourly-card {
+    width: 100%;
+    margin-top: 10px;
+}
+
 /* Estilos para el buscador */
 .search-box {
     margin-top: 20px;
@@ -355,7 +361,7 @@ body.dark-mode .toast {
 
 /* Hourly forecast styles */
 .hourly-forecast {
-    display: none;
+    display: flex;
     flex-wrap: nowrap;
     overflow-x: auto;
     gap: 10px;
@@ -365,13 +371,14 @@ body.dark-mode .toast {
 .hourly-weather {
     flex: 0 0 auto;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     align-items: center;
+    gap: 8px;
     background-color: var(--white-color);
     border: 1px solid var(--gray-light-color);
     border-radius: 8px;
-    padding: 5px;
-    width: 80px;
+    padding: 5px 8px;
+    width: max-content;
 }
 
 .hourly-weather img {

--- a/index.html
+++ b/index.html
@@ -54,7 +54,6 @@
                 <p id="today-description"></p>
                 <p id="today-temperature"></p>
                 <button class="expand-btn" onclick="toggleHourlyForecast('today')">Mostrar por horas</button>
-                <div class="hourly-forecast" id="today-hourly-forecast"></div>
             </div>
             
             <div class="weather-card" id="tomorrow">
@@ -63,7 +62,6 @@
                 <p id="tomorrow-description"></p>
                 <p id="tomorrow-temperature"></p>
                 <button class="expand-btn" onclick="toggleHourlyForecast('tomorrow')">Mostrar por horas</button>
-                <div class="hourly-forecast" id="tomorrow-hourly-forecast"></div>
             </div>
             
             <div class="weather-card" id="day-after-tomorrow">
@@ -72,9 +70,9 @@
                 <p id="day-after-tomorrow-description"></p>
                 <p id="day-after-tomorrow-temperature"></p>
                 <button class="expand-btn" onclick="toggleHourlyForecast('day-after-tomorrow')">Mostrar por horas</button>
-                <div class="hourly-forecast" id="day-after-tomorrow-hourly-forecast"></div>
             </div>
         </div>
+        <div id="hourly-cards"></div>
 
         <footer id="footer" class="absolute">
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -51,12 +51,14 @@ function updateWeatherCards(data) {
 }
 
 export async function toggleHourlyForecast(cardId) {
-  const card = document.getElementById(cardId);
   const existingCard = document.getElementById(`${cardId}-hourly-card`);
+  const container = document.getElementById('hourly-cards');
 
   if (existingCard) {
     existingCard.remove();
-    footer.classList.add('absolute');
+    if (!container.hasChildNodes()) {
+      footer.classList.add('absolute');
+    }
     return;
   }
 
@@ -85,7 +87,7 @@ export async function toggleHourlyForecast(cardId) {
     hourlyCard.id = `${cardId}-hourly-card`;
     hourlyCard.innerHTML = `<div class="hourly-forecast">${hourlyForecastContent}</div>`;
 
-    card.insertAdjacentElement('afterend', hourlyCard);
+    container.appendChild(hourlyCard);
     footer.classList.remove('absolute');
   }
 }

--- a/js/ui.js
+++ b/js/ui.js
@@ -52,36 +52,41 @@ function updateWeatherCards(data) {
 
 export async function toggleHourlyForecast(cardId) {
   const card = document.getElementById(cardId);
-  const hourlyForecastDiv = card.querySelector('.hourly-forecast');
+  const existingCard = document.getElementById(`${cardId}-hourly-card`);
 
-  if (hourlyForecastDiv.style.display === 'block') {
-    hourlyForecastDiv.style.display = 'none';
+  if (existingCard) {
+    existingCard.remove();
     footer.classList.add('absolute');
-  } else {
-    const city = document.getElementById('city-input').value.trim();
-    if (!city) {
-      showToast(t('hourlyWarning'), 'warning');
-      return;
-    }
+    return;
+  }
 
-    const index = cardId === 'today' ? 0 : cardId === 'tomorrow' ? 1 : 2;
-    const hourlyForecast = await getHourlyForecast(city, index);
+  const city = document.getElementById('city-input').value.trim();
+  if (!city) {
+    showToast(t('hourlyWarning'), 'warning');
+    return;
+  }
 
-    if (hourlyForecast) {
-      const hourlyForecastContent = hourlyForecast.map(hour => {
-        return `
-          <div class="hourly-weather">
-            <span class="hourly-time">${hour.time.slice(11, 16)}</span>
-            <img src="${hour.condition.icon}" alt="${hour.condition.text}">
-            <span class="hourly-temp">${hour.temp_c}°C</span>
-          </div>
-        `;
-      }).join('');
+  const index = cardId === 'today' ? 0 : cardId === 'tomorrow' ? 1 : 2;
+  const hourlyForecast = await getHourlyForecast(city, index);
 
-      hourlyForecastDiv.innerHTML = hourlyForecastContent;
-      hourlyForecastDiv.style.display = 'block';
-      footer.classList.remove('absolute');
-    }
+  if (hourlyForecast) {
+    const hourlyForecastContent = hourlyForecast.map(hour => {
+      return `
+        <div class="hourly-weather">
+          <span class="hourly-time">${hour.time.slice(11, 16)}</span>
+          <img src="${hour.condition.icon}" alt="${hour.condition.text}">
+          <span class="hourly-temp">${hour.temp_c}°C</span>
+        </div>
+      `;
+    }).join('');
+
+    const hourlyCard = document.createElement('div');
+    hourlyCard.className = 'weather-card hourly-card';
+    hourlyCard.id = `${cardId}-hourly-card`;
+    hourlyCard.innerHTML = `<div class="hourly-forecast">${hourlyForecastContent}</div>`;
+
+    card.insertAdjacentElement('afterend', hourlyCard);
+    footer.classList.remove('absolute');
   }
 }
 


### PR DESCRIPTION
## Summary
- display hourly forecast in a new card instead of inside the weather card
- lay out hourly forecast items horizontally

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886bce6950083338d4bba658f0d708d