### PR TITLE
Ensure old caches are removed

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -13,30 +13,24 @@ const ASSETS_TO_CACHE = [
   '/manifest.json'
 ];
 
-const nextCacheName = caches.keys().then(keys => {
-  const versions = keys
-    .filter(k => k.startsWith(CACHE_PREFIX))
-    .map(k => parseInt(k.replace(CACHE_PREFIX, ''), 10))
-    .filter(n => !isNaN(n));
-  const next = versions.length ? Math.max(...versions) + 1 : 1;
-  return `${CACHE_PREFIX}${next}`;
-});
+// Se genera un nombre único para la caché utilizando la fecha actual.
+// Al activarse un service worker nuevo se eliminarán las cachés que
+// no coincidan con este nombre para conservar sólo la versión más reciente.
+const CACHE_NAME = `${CACHE_PREFIX}${Date.now()}`;
 
 self.addEventListener('install', event => {
   self.skipWaiting();
   event.waitUntil(
-    nextCacheName.then(name => caches.open(name).then(cache => cache.addAll(ASSETS_TO_CACHE)))
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS_TO_CACHE))
   );
 });
 
 self.addEventListener('activate', event => {
   event.waitUntil(
-    nextCacheName.then(name =>
-      caches.keys().then(keys =>
-        Promise.all(
-          keys.filter(key => key.startsWith(CACHE_PREFIX) && key !== name)
-            .map(key => caches.delete(key))
-        )
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.filter(key => key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME)
+          .map(key => caches.delete(key))
       )
     ).then(() => self.clients.claim())
   );
@@ -45,32 +39,34 @@ self.addEventListener('activate', event => {
 self.addEventListener('fetch', event => {
   if (event.request.method !== 'GET') return;
 
-  event.respondWith(
-    nextCacheName.then(cacheName => {
-      if (event.request.mode === 'navigate') {
-        return fetch(event.request)
-          .then(response => {
-            const clone = response.clone();
-            caches.open(cacheName).then(cache => cache.put(event.request, clone));
-            return response;
-          })
-          .catch(() => caches.match('/offline.html'));
+  event.respondWith((async () => {
+    if (event.request.mode === 'navigate') {
+      try {
+        const response = await fetch(event.request);
+        const clone = response.clone();
+        const cache = await caches.open(CACHE_NAME);
+        cache.put(event.request, clone);
+        return response;
+      } catch {
+        return caches.match('/offline.html');
       }
+    }
 
-      if (event.request.url.startsWith(self.location.origin)) {
-        return caches.match(event.request).then(cached => {
-          const fetchPromise = fetch(event.request).then(networkResponse => {
-            if (networkResponse && networkResponse.ok) {
-              caches.open(cacheName).then(cache => cache.put(event.request, networkResponse.clone()));
-            }
-            return networkResponse;
-          }).catch(() => cached);
+    if (event.request.url.startsWith(self.location.origin)) {
+      const cached = await caches.match(event.request);
+      const fetchPromise = fetch(event.request)
+        .then(async networkResponse => {
+          if (networkResponse && networkResponse.ok) {
+            const cache = await caches.open(CACHE_NAME);
+            await cache.put(event.request, networkResponse.clone());
+          }
+          return networkResponse;
+        })
+        .catch(() => cached);
 
-          return cached || fetchPromise;
-        });
-      }
+      return cached || fetchPromise;
+    }
 
-      return fetch(event.request);
-    })
-  );
+    return fetch(event.request);
+  })());
 });


### PR DESCRIPTION
## Summary
- generate unique cache name for each service worker
- remove previous caches when activating new worker
- update fetch handler to use new constant

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886c38d880483338db05e43d9073cbf