### PR TITLE
Fix import casing to restore Vite build

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,13 +35,13 @@
         />
 
         <!-- custom css -->
-        <link rel="stylesheet" href="src/styles/style.css" />
+        <link rel="stylesheet" href="/src/styles/style.css" />
 
         <link rel="manifest" href="manifest.json" />
         <meta name="theme-color" content="#3d94f0" />
     </head>
     <body>
         <div id="root"></div>
-        <script type="module" src="dist/assets/index-DFhgZx0Z.js"></script>
+        <script type="module" src="/src/main.tsx"></script>
     </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import WeatherDashboard from './components/WeatherDashboard';
-import Navbar from './components/Navbar';
-import Footer from './components/Footer';
+import Navbar from './components/navbar';
+import Footer from './components/footer';
 import { useTheme } from './hooks/useTheme';
 import { useLang } from './hooks/useLang';
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,5 @@
 import ReactDOM from 'react-dom/client';
-import App from './app';
+import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root')!);
 root.render(<App />);


### PR DESCRIPTION
## Summary
- point dev index.html to source files so Vite can build entrypoints
- fix case-sensitive component imports to avoid resolution errors on Linux

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module '../server')*


------
https://chatgpt.com/codex/tasks/task_e_68c3e842d9888327884ee1d113738935